### PR TITLE
TWEAK: Support the URL scheme in production (dev#1693)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ module.exports = config => {
   router.get('/update/win32/:version/RELEASES', routes.releases)
   router.get('/update/win32/x64/:version/RELEASES', routes.releases)
   router.get('/update/darwin/:arch/:version', routes.updateDarwinWithArch)
-  router.get('/download/darwin/:arch/:version', routes.downloadDarwinWithArch)
+  router.get('/download/mac/:arch', routes.downloadDarwinWithArch)
   router.get('/download/file/:filename', routes.downloadFile)
   return (req, res) => {
     router(req, res, finalhandler(req, res))

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -231,9 +231,9 @@ module.exports = ({ cache, config }) => {
   }
 
   exports.downloadDarwinWithArch = async (req, res) => {
-    const { arch, version } = req.params
+    const { arch } = req.params
 
-    res.setHeader('Location', (arch === 'arm64' ? `/download/darwin_${arch}/${version}` : `/download/darwin/${version}`))
+    res.setHeader('Location', (arch === 'arm64' ? `/download/dmg_${arch}` : '/download/dmg'))
     send(res, 302)
   }
 


### PR DESCRIPTION
In production we support two download URLs

https://electron-update.fathom.video/download/mac/x64
https://electron-update.fathom.video/download/mac/arm64

This just fixes the hazel route to match that. That way when we update the main update server there should be no downtime.